### PR TITLE
[Fix] (Emergecy) Bump example Android Kotlin to 2.2.20 for Flutter 3.47.2

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.12.2' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Change Log
* Fix the `example_android_build` job failure introduced by the Flutter 3.47.2 upgrade (#33).
  * Raise the example Android project's Kotlin Gradle Plugin version from `2.1.0` to `2.2.20` in `example/android/settings.gradle`.
  * Flutter 3.47.2 raised the minimum supported Kotlin Gradle Plugin version to `2.2.20`. With `2.1.0`, `flutter build apk --release` failed while applying `dev.flutter.flutter-gradle-plugin` (`Your project's Kotlin version (2.1.0) is lower than Flutter's minimum supported version of 2.2.20`).
  * Verified locally with `flutter build apk --release` (builds `app-release.apk` successfully).

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)